### PR TITLE
Add launcher icon toggle option

### DIFF
--- a/manager/app/src/main/AndroidManifest.xml
+++ b/manager/app/src/main/AndroidManifest.xml
@@ -25,12 +25,34 @@
         <activity
             android:name=".ui.MainActivity"
             android:exported="true"
-            android:theme="@style/Theme.KernelSU">
+            android:theme="@style/Theme.KernelSU" />
+
+        <!-- Default launcher icon -->
+        <activity-alias
+            android:name=".MainActivityAlias"
+            android:exported="true"
+            android:targetActivity=".ui.MainActivity"
+            android:icon="@mipmap/ic_launcher"
+            android:label="@string/app_name">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
-        </activity>
+        </activity-alias>
+
+        <!-- Android native launcher icon -->
+        <activity-alias
+            android:name=".MainActivityAndroidAlias"
+            android:exported="true"
+            android:targetActivity=".ui.MainActivity"
+            android:icon="@android:drawable/sym_def_app_icon"
+            android:enabled="false"
+            android:label="@string/app_name">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity-alias>
 
         <activity
             android:name=".ui.webui.WebUIActivity"

--- a/manager/app/src/main/res/values-zh-rCN/strings.xml
+++ b/manager/app/src/main/res/values-zh-rCN/strings.xml
@@ -195,6 +195,8 @@
     <string name="hide_susfs_status_summary">隐藏主页上的 SuSFS 状态信息</string>
     <string name="hide_link_card">隐藏链接卡片</string>
     <string name="hide_link_card_summary">隐藏主页上的链接卡片信息</string>
+    <string name="use_android_icon">使用原生图标</string>
+    <string name="use_android_icon_summary">在现有图标和安卓原生图标之间切换</string>
     <string name="theme_mode">主题模式</string>
     <string name="theme_follow_system">跟随系统</string>
     <string name="theme_light">浅色</string>

--- a/manager/app/src/main/res/values/strings.xml
+++ b/manager/app/src/main/res/values/strings.xml
@@ -197,6 +197,8 @@
     <string name="hide_susfs_status_summary">Hide SuSFS status information on the home page</string>
     <string name="hide_link_card">Hide Link Card Status</string>
     <string name="hide_link_card_summary">Hide link card information on the home page</string>
+    <string name="use_android_icon">Use Android icon</string>
+    <string name="use_android_icon_summary">Toggle between the current icon and the Android default icon</string>
     <string name="theme_mode">Theme</string>
     <string name="theme_follow_system">Follow system</string>
     <string name="theme_light">Light</string>


### PR DESCRIPTION
## Summary
- add Android native icon alias in manifest
- add state and switch to toggle launcher icon in more settings
- persist preference and apply icon change
- update English and Chinese strings

## Testing
- `./gradlew tasks --all` *(fails: No route to host)*

------
https://chatgpt.com/codex/tasks/task_b_683c25f663e48323b48e78a283d50336