### PR TITLE
Add launcher icon toggle option

### DIFF
--- a/manager/app/src/main/AndroidManifest.xml
+++ b/manager/app/src/main/AndroidManifest.xml
@@ -25,12 +25,34 @@
         <activity
             android:name=".ui.MainActivity"
             android:exported="true"
-            android:theme="@style/Theme.KernelSU">
+            android:theme="@style/Theme.KernelSU" />
+
+        <!-- Default launcher icon -->
+        <activity-alias
+            android:name=".MainActivityAlias"
+            android:exported="true"
+            android:targetActivity=".ui.MainActivity"
+            android:icon="@mipmap/ic_launcher"
+            android:label="@string/app_name">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
-        </activity>
+        </activity-alias>
+
+        <!-- Android native launcher icon -->
+        <activity-alias
+            android:name=".MainActivityAndroidAlias"
+            android:exported="true"
+            android:targetActivity=".ui.MainActivity"
+            android:icon="@mipmap/ic_android"
+            android:enabled="false"
+            android:label="@string/app_name">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity-alias>
 
         <activity
             android:name=".ui.webui.WebUIActivity"

--- a/manager/app/src/main/res/drawable/ic_android_foreground.xml
+++ b/manager/app/src/main/res/drawable/ic_android_foreground.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+    <group
+        android:scaleX="0.135"
+        android:scaleY="0.135">
+        <path
+            android:pathData="M 259 259 H 541 V 541 H 259 V 259 Z"
+            android:strokeWidth="18"
+            android:strokeColor="#1e110d" />
+        <path
+            android:fillColor="#1e110d"
+            android:pathData="M 257 257 H 407 V 407 H 257 V 257 Z" />
+        <path
+            android:fillColor="#1e110d"
+            android:pathData="M 393 393 H 543 V 543 H 393 V 393 Z" />
+    </group>
+</vector>

--- a/manager/app/src/main/res/drawable/ic_android_monochrome.xml
+++ b/manager/app/src/main/res/drawable/ic_android_monochrome.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+    <group
+        android:scaleX="0.135"
+        android:scaleY="0.135">
+        <path
+            android:pathData="M 259 259 H 541 V 541 H 259 V 259 Z"
+            android:strokeWidth="18"
+            android:strokeColor="#000000" />
+        <path
+            android:fillColor="#000000"
+            android:pathData="M 257 257 H 407 V 407 H 257 V 257 Z" />
+        <path
+            android:fillColor="#000000"
+            android:pathData="M 393 393 H 543 V 543 H 393 V 393 Z" />
+    </group>
+</vector>

--- a/manager/app/src/main/res/mipmap-anydpi-v26/ic_android.xml
+++ b/manager/app/src/main/res/mipmap-anydpi-v26/ic_android.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@color/ic_launcher_background"/>
+    <foreground android:drawable="@drawable/ic_android_foreground"/>
+    <monochrome android:drawable="@drawable/ic_android_monochrome"/>
+</adaptive-icon>

--- a/manager/app/src/main/res/values-zh-rCN/strings.xml
+++ b/manager/app/src/main/res/values-zh-rCN/strings.xml
@@ -195,6 +195,8 @@
     <string name="hide_susfs_status_summary">隐藏主页上的 SuSFS 状态信息</string>
     <string name="hide_link_card">隐藏链接卡片</string>
     <string name="hide_link_card_summary">隐藏主页上的链接卡片信息</string>
+    <string name="use_android_icon">使用原生图标</string>
+    <string name="use_android_icon_summary">在现有图标和安卓原生图标之间切换</string>
     <string name="theme_mode">主题模式</string>
     <string name="theme_follow_system">跟随系统</string>
     <string name="theme_light">浅色</string>

--- a/manager/app/src/main/res/values/strings.xml
+++ b/manager/app/src/main/res/values/strings.xml
@@ -197,6 +197,8 @@
     <string name="hide_susfs_status_summary">Hide SuSFS status information on the home page</string>
     <string name="hide_link_card">Hide Link Card Status</string>
     <string name="hide_link_card_summary">Hide link card information on the home page</string>
+    <string name="use_android_icon">Use Android icon</string>
+    <string name="use_android_icon_summary">Toggle between the current icon and the Android default icon</string>
     <string name="theme_mode">Theme</string>
     <string name="theme_follow_system">Follow system</string>
     <string name="theme_light">Light</string>


### PR DESCRIPTION
## Summary
- add Android native icon alias in manifest
- add state and switch to toggle launcher icon in more settings
- persist preference and apply icon change
- add custom vector icons for the Android alias

## Testing
- `./gradlew tasks --all` *(fails: No route to host)*

------
https://chatgpt.com/codex/tasks/task_b_683c25f663e48323b48e78a283d50336