### PR TITLE
Add alternate app icon toggle

### DIFF
--- a/manager/app/src/main/AndroidManifest.xml
+++ b/manager/app/src/main/AndroidManifest.xml
@@ -32,6 +32,19 @@
             </intent-filter>
         </activity>
 
+        <activity-alias
+            android:name=".ui.MainActivityAlias"
+            android:exported="true"
+            android:enabled="false"
+            android:icon="@mipmap/ic_launcher_alt"
+            android:roundIcon="@mipmap/ic_launcher_alt_round"
+            android:targetActivity=".ui.MainActivity">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity-alias>
+
         <activity
             android:name=".ui.webui.WebUIActivity"
             android:autoRemoveFromRecents="true"

--- a/manager/app/src/main/java/com/sukisu/ultra/ui/screen/MoreSettings.kt
+++ b/manager/app/src/main/java/com/sukisu/ultra/ui/screen/MoreSettings.kt
@@ -4,6 +4,8 @@ import android.annotation.SuppressLint
 import android.app.Activity
 import android.content.Context
 import android.content.Intent
+import android.content.ComponentName
+import android.content.pm.PackageManager
 import android.content.res.Configuration
 import android.net.Uri
 import android.os.Build
@@ -104,6 +106,19 @@ import kotlin.math.roundToInt
  */
 fun saveCardConfig(context: Context) {
     CardConfig.save(context)
+}
+
+fun toggleLauncherIcon(context: Context, useAlt: Boolean) {
+    val pm = context.packageManager
+    val main = ComponentName(context, MainActivity::class.java.name)
+    val alt = ComponentName(context, "${MainActivity::class.java.name}Alias")
+    if (useAlt) {
+        pm.setComponentEnabledSetting(main, PackageManager.COMPONENT_ENABLED_STATE_DISABLED, PackageManager.DONT_KILL_APP)
+        pm.setComponentEnabledSetting(alt, PackageManager.COMPONENT_ENABLED_STATE_ENABLED, PackageManager.DONT_KILL_APP)
+    } else {
+        pm.setComponentEnabledSetting(alt, PackageManager.COMPONENT_ENABLED_STATE_DISABLED, PackageManager.DONT_KILL_APP)
+        pm.setComponentEnabledSetting(main, PackageManager.COMPONENT_ENABLED_STATE_ENABLED, PackageManager.DONT_KILL_APP)
+    }
 }
 
 @SuppressLint("LocalContextConfigurationRead", "ObsoleteSdkInt")
@@ -339,6 +354,16 @@ fun MoreSettingsScreen() {
     var cardDim by rememberSaveable { mutableFloatStateOf(CardConfig.cardDim) }
     var isCustomBackgroundEnabled by rememberSaveable {
         mutableStateOf(ThemeConfig.customBackgroundUri != null)
+    }
+
+    // Alternate icon state
+    var useAltIcon by remember { mutableStateOf(prefs.getBoolean("use_alt_icon", false)) }
+
+    val onUseAltIconChange = { newValue: Boolean ->
+        prefs.edit { putBoolean("use_alt_icon", newValue) }
+        useAltIcon = newValue
+        toggleLauncherIcon(context, newValue)
+        Toast.makeText(context, context.getString(R.string.icon_switched), Toast.LENGTH_SHORT).show()
     }
 
     // 图片编辑状态
@@ -849,6 +874,16 @@ fun MoreSettingsScreen() {
                 title = stringResource(R.string.custom_settings),
                 icon = Icons.Default.Settings
             ) {
+                // Launcher icon switch
+                SwitchItem(
+                    icon = Icons.Default.Android,
+                    title = stringResource(R.string.icon_switch_title),
+                    summary = stringResource(R.string.icon_switch_summary),
+                    checked = useAltIcon
+                ) {
+                    onUseAltIconChange(it)
+                }
+
                 // 添加简洁模式开关
                 SwitchItem(
                     icon = Icons.Filled.Brush,

--- a/manager/app/src/main/res/drawable/ic_launcher_foreground_alt.xml
+++ b/manager/app/src/main/res/drawable/ic_launcher_foreground_alt.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+
+    <group
+        android:scaleX="0.135"
+        android:scaleY="0.135">
+        <path
+            android:pathData="M 259 259 H 541 V 541 H 259 V 259 Z"
+            android:strokeWidth="18"
+            android:strokeColor="#1e110d" />
+        <path
+            android:fillColor="#1e110d"
+            android:pathData="M 257 257 H 407 V 407 H 257 V 257 Z" />
+        <path
+            android:fillColor="#1e110d"
+            android:pathData="M 393 393 H 543 V 543 H 393 V 393 Z" />
+    </group>
+</vector>

--- a/manager/app/src/main/res/drawable/ic_launcher_monochrome_alt.xml
+++ b/manager/app/src/main/res/drawable/ic_launcher_monochrome_alt.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+
+    <group
+        android:scaleX="0.135"
+        android:scaleY="0.135">
+        <path
+            android:pathData="M 259 259 H 541 V 541 H 259 V 259 Z"
+            android:strokeWidth="18"
+            android:strokeColor="#000000" />
+        <path
+            android:fillColor="#000000"
+            android:pathData="M 257 257 H 407 V 407 H 257 V 257 Z" />
+        <path
+            android:fillColor="#000000"
+            android:pathData="M 393 393 H 543 V 543 H 393 V 393 Z" />
+    </group>
+</vector>

--- a/manager/app/src/main/res/mipmap-anydpi-v26/ic_launcher_alt.xml
+++ b/manager/app/src/main/res/mipmap-anydpi-v26/ic_launcher_alt.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@color/ic_launcher_background"/>
+    <foreground android:drawable="@drawable/ic_launcher_foreground_alt"/>
+    <monochrome android:drawable="@drawable/ic_launcher_monochrome_alt" />
+</adaptive-icon>

--- a/manager/app/src/main/res/mipmap-anydpi-v26/ic_launcher_alt_round.xml
+++ b/manager/app/src/main/res/mipmap-anydpi-v26/ic_launcher_alt_round.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@color/ic_launcher_background"/>
+    <foreground android:drawable="@drawable/ic_launcher_foreground_alt"/>
+</adaptive-icon>

--- a/manager/app/src/main/res/values-zh-rCN/strings.xml
+++ b/manager/app/src/main/res/values-zh-rCN/strings.xml
@@ -321,6 +321,9 @@
     <string name="susfs_disabled">SuSFS 已禁用</string>
     <string name="background_set_success">背景设置成功</string>
     <string name="background_removed">已移除自定义背景</string>
+    <string name="icon_switch_title">切换启动器图标</string>
+    <string name="icon_switch_summary">在默认图标和备用图标之间切换</string>
+    <string name="icon_switched">已切换图标</string>
     <string name="root_require_for_install">需要 root 权限</string>
     <!-- KPM display settings -->
     <string name="show_kpm_info">显示 KPM 功能</string>

--- a/manager/app/src/main/res/values-zh-rHK/strings.xml
+++ b/manager/app/src/main/res/values-zh-rHK/strings.xml
@@ -323,6 +323,9 @@
     <string name="susfs_disabled">SuSFS 未啟用</string>
     <string name="background_set_success">背景設置成功</string>
     <string name="background_removed">刪除背景</string>
+    <string name="icon_switch_title">切換啟動器圖示</string>
+    <string name="icon_switch_summary">在預設圖示與替代圖示之間切換</string>
+    <string name="icon_switched">圖示已切換</string>
     <string name="root_require_for_install">需要root權限</string>
     <!-- KPM display settings -->
     <string name="show_kpm_info">顯示KPM功能</string>

--- a/manager/app/src/main/res/values-zh-rTW/strings.xml
+++ b/manager/app/src/main/res/values-zh-rTW/strings.xml
@@ -321,6 +321,9 @@
     <string name="susfs_disabled">SuSFS disabled</string>
     <string name="background_set_success">Background set successfully</string>
     <string name="background_removed">Removed custom backgrounds</string>
+    <string name="icon_switch_title">Alternate launcher icon</string>
+    <string name="icon_switch_summary">Toggle between default and alternate icon</string>
+    <string name="icon_switched">Icon switched</string>
     <string name="root_require_for_install">Requires root privileges</string>
     <!-- KPM display settings -->
     <string name="show_kpm_info">Display KPM Function</string>

--- a/manager/app/src/main/res/values/strings.xml
+++ b/manager/app/src/main/res/values/strings.xml
@@ -323,6 +323,9 @@
     <string name="susfs_disabled">SuSFS disabled</string>
     <string name="background_set_success">Background set successfully</string>
     <string name="background_removed">Removed custom backgrounds</string>
+    <string name="icon_switch_title">Alternate launcher icon</string>
+    <string name="icon_switch_summary">Toggle between default and alternate icon</string>
+    <string name="icon_switched">Icon switched</string>
     <string name="root_require_for_install">Requires root privileges</string>
     <!-- KPM display settings -->
     <string name="show_kpm_info">Display KPM Function</string>


### PR DESCRIPTION
## Summary
- add alternate launcher icon resources
- create activity alias for alternate icon
- add setting to toggle app icon in more settings screen
- move icon toggle into custom settings section
- translate icon toggle strings into Chinese

## Testing
- `./gradlew tasks --all` *(fails: No route to host)*

------
https://chatgpt.com/codex/tasks/task_b_683c498d4770832380c09edf84304e57